### PR TITLE
Fix symlink not reported if target file is not executable

### DIFF
--- a/which_problem/src/file_state.rs
+++ b/which_problem/src/file_state.rs
@@ -7,6 +7,7 @@ pub(crate) fn file_state(path: &Path) -> FileState {
     if path.is_symlink() {
         match symlink_state(path) {
             SymlinkState::Valid => FileState::Valid,
+            SymlinkState::NotExecutable => FileState::NotExecutable,
             _ => FileState::BadSymlink,
         }
     } else if path.exists() {

--- a/which_problem/src/program.rs
+++ b/which_problem/src/program.rs
@@ -56,6 +56,15 @@ impl Display for Program {
         if let Some(found) = executable {
             let file = &found.path;
             writeln!(f, r#"Program {name:?} found at {file:?}"#)?;
+        } else if let Some(found) = found_files
+            .iter()
+            .find(|p| matches!(p.state, FileState::NotExecutable))
+        {
+            writeln!(
+                f,
+                r#"Program {name:?} found at {file:?} but is not executable"#,
+                file = found.path
+            )?;
         } else {
             writeln!(f, r#"Program {name:?} not found"#)?;
 


### PR DESCRIPTION
Prior to this change, if a symlink matching the target program was found but the file it pointed to was not executable, it would be reported as not found. E.g.;

```
Program "yarn" not found
    
Info: No other executables with the same name are found on the PATH
    
Info: These executables have the closest spelling to "yarn" but did not match:
      "man", "yacc", "tar"
    
Info: The following directories on PATH were searched (top to bottom):
  - [OK   ] "/layers/heroku_nodejs/yarn_vendored/bin"
  - [OK   ] "/layers/heroku_nodejs/dist/bin"
  - [EMPTY] "/usr/local/sbin"
  - [EMPTY] "/usr/local/bin"
  - [OK   ] "/usr/sbin"
  - [OK   ] "/usr/bin"
  - [OK   ] "/sbin"
  - [OK   ] "/bin"
Explanation:
    [OK   ] - Path part is a valid, non-empty, directory
    [EMPTY] - Path part directory exists, but it is empty
```

Now, matching symlinks with missing executable permissions will be properly reported. This also applies to regular files with missing executable permissions when there is only a single file found. E.g.;

```
Program "yarn" found at "/var/folders/r4/xq3q_hjj2v1ghqlnr1k1zrdw0000gp/T/.tmpvUsjCG/yarn" but is not executable

Info: No other executables with the same name are found on the PATH

Info: These executables have the closest spelling to "yarn" but did not match:
      "yarn-3.10.0.cjs"

Info: The following directories on PATH were searched (top to bottom):
  - [OK] "/var/folders/r4/xq3q_hjj2v1ghqlnr1k1zrdw0000gp/T/.tmpvUsjCG"
Explanation:
    [OK] - Path part is a valid, non-empty, directory
```