### PR TITLE
Use `fsaccess` for executable check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Use `fsaccess` for executable check. [#12](https://github.com/schneems/which_problem/pull/12)
+
+The `fsaccess` crate uses https://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html on unix systems which effectively delegates the question of if it's executable or not to the OS. This handles edge cases like where a file might have executable permissions, but a parent directory does not. From https://github.com/schneems/path_facts/blob/3400c1020a074713bc72a7193d23cf1a5d8f4317/README.md:
+
+> Permissions of a path depend not just on the permissions of the specific file/directory but also on other things, such as inherited permissions from parent directories.
+>
+> This means that to know the "effective" permissions of a file, you need to know the permissions of all its parent directories (we use the faccess crate for this)
+>
+> More permissions info at https://www.redhat.com/sysadmin/linux-file-permissions-explained and https://www.redhat.com/sysadmin/suid-sgid-sticky-bit
+
 ## 0.1.1
 
 - Fix symlink not reported if target file is not executable [#3](https://github.com/schneems/which_problem/pull/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.1.2
+
 - Use `fsaccess` for executable check. [#12](https://github.com/schneems/which_problem/pull/12)
 
 The `fsaccess` crate uses https://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html on unix systems which effectively delegates the question of if it's executable or not to the OS. This handles edge cases like where a file might have executable permissions, but a parent directory does not. From https://github.com/schneems/path_facts/blob/3400c1020a074713bc72a7193d23cf1a5d8f4317/README.md:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ homepage = "https://github.com/schneems/which_problem"
 repository = "https://github.com/schneems/which_problem"
 
 [workspace.dependencies]
+# We use `faccess` to check **effective** permisisons on disk (includes inherited values)
+faccess = "0.2.4"
 which_problem = { version = "0.1.1", path = "which_problem" }
 cargo-whichp = { version = "0.1.1", path = "cargo-whichp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["which_problem", "cargo-whichp"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 rust-version = "1.64"
 edition = "2021"
 license = "MIT"

--- a/which_problem/Cargo.toml
+++ b/which_problem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "which_problem"
-version = "0.1.1"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/which_problem/Cargo.toml
+++ b/which_problem/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/which_problem"
 keywords = ["executable", "which", "lookup"]
 
 [dependencies]
-is_executable = "1.0.1"
+faccess.workspace = true
 itertools = "0.14.0"
 ordered-float = "5.1.0"
 rayon = "1.6.1"

--- a/which_problem/src/file_state.rs
+++ b/which_problem/src/file_state.rs
@@ -1,4 +1,4 @@
-use is_executable::IsExecutable;
+use faccess::PathExt;
 use std::fmt::Display;
 use std::path::Path;
 
@@ -13,7 +13,7 @@ pub(crate) fn file_state(path: &Path) -> FileState {
     } else if path.exists() {
         if path.is_dir() {
             FileState::IsDir
-        } else if path.is_executable() {
+        } else if path.executable() {
             FileState::Valid
         } else {
             FileState::NotExecutable

--- a/which_problem/src/lib.rs
+++ b/which_problem/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
     use crate::file_state::{file_state, FileState};
     use crate::path_with_state::PathWithState;
     use crate::which::Which;
-    use is_executable::IsExecutable;
+    use faccess::PathExt;
     use path_part::PartState;
     use std::ffi::OsString;
     use std::os::unix::fs::PermissionsExt;
@@ -124,7 +124,7 @@ mod tests {
         let mode = perms.mode() | 0o111;
         std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode)).unwrap();
 
-        assert!(file.is_executable());
+        assert!(file.executable());
 
         let program = Which {
             program: name,


### PR DESCRIPTION
The `fsaccess` crate uses https://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html on unix systems which effectively delegates the question of if it's executable or not to the OS. This handles edge cases like where a file might have executable permissions, but a parent directory does not. From https://github.com/schneems/path_facts/blob/3400c1020a074713bc72a7193d23cf1a5d8f4317/README.md:

> Permissions of a path depend not just on the permissions of the specific file/directory but also on other things, such as inherited permissions from parent directories.
>
> This means that to know the "effective" permissions of a file, you need to know the permissions of all its parent directories (we use the faccess crate for this)
>
> More permissions info at https://www.redhat.com/sysadmin/linux-file-permissions-explained and https://www.redhat.com/sysadmin/suid-sgid-sticky-bit